### PR TITLE
Remove unnecessary space in description when there's a comma after the name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ const wikipediaDeadOrAlive = {
     const openBracketPos = firstSentence.indexOf('(');
     const closeBracketPos = firstSentence.lastIndexOf(')');
 
-    const description = `${firstSentence.substring(0, openBracketPos).trim()} ${firstSentence.substring(closeBracketPos + 1).trim()}`;
+    const descriptionPart1 = firstSentence.substring(0, openBracketPos).trim();
+    const descriptionPart2 = firstSentence.substring(closeBracketPos + 1).trim();
+    const description = `${descriptionPart1}${descriptionPart2.startsWith(',') ? '' : ' '}${descriptionPart2}`;
     
     let datePart = firstSentence.substring(openBracketPos, closeBracketPos + 1).trim();
     const firstSemicolonPos = datePart.indexOf(';');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikipediadeadoralive",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Wikipedia Celebrity Dead or Alive",
   "main": "index.js",
   "scripts": {

--- a/test/deadoralive.test.js
+++ b/test/deadoralive.test.js
@@ -94,7 +94,7 @@ test('Lisa Lopes, for for trailing space after name in description...', async ()
   expect(result.dead).toBe(true);
   expect(result.died).toBe('2002');
   expect(result.description.length).toBeGreaterThan(0);
-  expect(result.description.startsWith('Lisa Nicole Lopes,').toBe(true));
+  expect(result.description.startsWith('Lisa Nicole Lopes,')).toBe(true);
 });
 // Test for no pageName provided.
 test('pageName is undefined...', async () => {

--- a/test/deadoralive.test.js
+++ b/test/deadoralive.test.js
@@ -86,6 +86,16 @@ test('Simon Prickett, not on wikipedia...', async () => {
   await expect(wikipediaDeadOrAlive.getStatus('Simon_Prickett')).rejects.toThrow('No extract: Page doesn\'t exist, or wrong type of page!');
 });
 
+// Tests for trailing space after name in description.
+test('Lisa Lopes, for for trailing space after name in description...', async () => {
+  const result = await wikipediaDeadOrAlive.getStatus('Lisa_Lopes');
+
+  expect(result.name).toBe('Lisa Lopes');
+  expect(result.dead).toBe(true);
+  expect(result.died).toBe('2002');
+  expect(result.description.length).toBeGreaterThan(0);
+  expect(result.description.startsWith('Lisa Nicole Lopes,').toBe(true));
+});
 // Test for no pageName provided.
 test('pageName is undefined...', async () => {
   expect.assertions(1);


### PR DESCRIPTION
Fixes #7 and adds a test case for Lisa "Left Eye" Lopes.